### PR TITLE
Don't kill process where `killProcs` is called.

### DIFF
--- a/index.js
+++ b/index.js
@@ -383,6 +383,8 @@ module.exports.killProcs = procName => {
     return self.__findProcess("name", procName).then(procList => {
 
         return procList.forEach(proc => {
+
+            if (process.pid === +proc.pid) return;
             try {
                 process.kill(proc.pid, "SIGTERM");
                 logger.debug(`Kill ${procName} with PID ${proc.pid}`);


### PR DESCRIPTION
Problem: `killProcs` method may find the same process where it is
called. In this cases this process should be missed and not killed.